### PR TITLE
Add RC scripts dependency on daemon

### DIFF
--- a/overlay/usr/local/etc/rc.d/paperlessconsumer
+++ b/overlay/usr/local/etc/rc.d/paperlessconsumer
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# PROVIDE: paperlessconsumer
+# REQUIRE: DAEMON
+
 . /etc/rc.subr
 
 

--- a/overlay/usr/local/etc/rc.d/paperlessscheduler
+++ b/overlay/usr/local/etc/rc.d/paperlessscheduler
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# PROVIDE: paperlessscheduler
+# REQUIRE: DAEMON
+
 . /etc/rc.subr
 
 

--- a/overlay/usr/local/etc/rc.d/paperlesswebserver
+++ b/overlay/usr/local/etc/rc.d/paperlesswebserver
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# PROVIDE: paperlessscheduler
+# REQUIRE: DAEMON
+
 . /etc/rc.subr
 
 


### PR DESCRIPTION
Without this requirement, when configured to start automatically, the services would fail to start when the jail starts.

To be clear: starting the services manually (ex: `service paperlesswebserver start`) worked, they just didn't automatically start on jail start. This fixed it for me.

PS: thanks for the repository, it was the only way I found to get paperless running on TrueNAS.