### PR TITLE
Fix document classifier dependencies

### DIFF
--- a/overlay/tmp/paperless_install
+++ b/overlay/tmp/paperless_install
@@ -3,7 +3,7 @@
 
 mkdir -p /opt/paperless/consume
 mkdir -p /opt/paperless/media
-python3.9 -m venv venv
+python3.9 -m venv --system-site-packages venv
 sed -i "" -e '/scikit-learn/d;/pikepdf/d;/scipy/d;/numpy/d' /opt/paperless/requirements.txt
 . venv/bin/activate
 pip install -q -q --upgrade pip
@@ -11,5 +11,8 @@ pip install -q -q -r requirements.txt
 cd src
 python3 manage.py migrate
 DJANGO_SUPERUSER_PASSWORD=admin python3 manage.py createsuperuser --noinput --email=root@localhost --username=admin
+python3 -W ignore::RuntimeWarning -m nltk.downloader -d "/opt/paperless/data/nltk" snowball_data
+python3 -W ignore::RuntimeWarning -m nltk.downloader -d "/opt/paperless/data/nltk" stopwords
+python3 -W ignore::RuntimeWarning -m nltk.downloader -d "/opt/paperless/data/nltk" punkt
 deactivate
 

--- a/post_install.sh
+++ b/post_install.sh
@@ -17,6 +17,9 @@ chown -R paperless:paperless /opt/paperless
 
 sed -i "" -e 's/#PAPERLESS_CONSUMER_POLLING/PAPERLESS_CONSUMER_POLLING/' /opt/paperless/paperless.conf
 sed -i "" -e 's/#PAPERLESS_DATA_DIR/PAPERLESS_DATA_DIR/' /opt/paperless/paperless.conf
+sed -i "" -e  "/PAPERLESS_DATA_DIR/ a\\
+PAPERLESS_NLTK_DIR=../data/nltk\
+" /opt/paperless/paperless.conf
 sed -i "" -e 's/#PAPERLESS_MEDIA_ROOT/PAPERLESS_MEDIA_ROOT/' /opt/paperless/paperless.conf
 sed -i "" -e 's/#PAPERLESS_CONSUMPTION_DIR/PAPERLESS_CONSUMPTION_DIR/' /opt/paperless/paperless.conf
 sed -i "" -e 's/#PAPERLESS_REDIS/PAPERLESS_REDIS/' /opt/paperless/paperless.conf


### PR DESCRIPTION
Although I fed my instance loads of the same type of document, the ML-powered classified never kicked in, and I kept getting this log entry:
```
[DEBUG] [paperless.classifier] Document classification model does not exist (yet), not performing automatic matching.
```

I tried running the classifier command manually (`python manage.py document_create_classifier`, inside the venv) and started getting the appropriate errors.

The fix consists of:

1. Giving Python venv access to the pkg installed dependencies (`--system-site-packages`), like py39-scikit-learn.
    1. To test it, simply run `python3.9 -c "import sklearn; sklearn.show_versions()"` outside (works) and inside (fails) the venv.
    2. Without it, if you ran `python manage.py document_create_classifier`, you'd get this error:
```
[WARNING] [paperless.tasks] Classifier error: No module named 'sklearn'
```

2. Download NLTK ML data according to docs:
https://github.com/paperless-ngx/paperless-ngx/blob/83f9f2d3870556a8f55167cbc89375fc967965a8/docs/setup.md?plain=1#L523
    1. Without it, if you ran `python manage.py document_create_classifier` (after the fix 1), you'd get this error:
```
[WARNING] [paperless.tasks] Classifier error:
**********************************************************************
  Resource [93mstopwords[0m not found.
  Please use the NLTK Downloader to obtain the resource:
  [31m>>> import nltk
  >>> nltk.download('stopwords')
  [0m
  For more information see: https://www.nltk.org/data.html
  Attempted to load [93mcorpora/stopwords[0m
  Searched in:
    - PosixPath('/usr/share/nltk_data')
**********************************************************************
```

Now my documents are getting automatically classified.