### PR TITLE
Add poppler-utils pkg

### DIFF
--- a/iocage-plugin-paperless-ngx.json
+++ b/iocage-plugin-paperless-ngx.json
@@ -34,7 +34,8 @@
         "py39-sqlite3",
 	"libxml2",
 	"libxslt",
-        "expect"
+        "expect",
+        "poppler-utils"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
This package contains pdftotext used during PDF OCR.

Without this package, when adding a PDF document, you'd get this log message:
```
[WARNING] [paperless.parsing.tesseract] Error while getting text from PDF document with pdftotext
Traceback (most recent call last):
  File "/opt/paperless/src/paperless_tesseract/parsers.py", line 145, in extract_text
    subprocess.run(
  File "/usr/local/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/local/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.9/subprocess.py", line 1837, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'pdftotext'
```