### PR TITLE
Move py39-scikit-learn dependency to Pip

### DIFF
--- a/iocage-plugin-paperless-ngx.json
+++ b/iocage-plugin-paperless-ngx.json
@@ -9,7 +9,6 @@
     "pkgs": [
         "py39-pip",
         "py39-pikepdf",
-	"py39-scikit-learn",
         "liberation-fonts-ttf",
         "imagemagick7",
         "zbar",

--- a/post_install.sh
+++ b/post_install.sh
@@ -15,6 +15,9 @@ cd /opt/paperless
 chown -R paperless:paperless /opt/paperless
 
 
+pip install scikit-learn
+
+
 sed -i "" -e 's/#PAPERLESS_CONSUMER_POLLING/PAPERLESS_CONSUMER_POLLING/' /opt/paperless/paperless.conf
 sed -i "" -e 's/#PAPERLESS_DATA_DIR/PAPERLESS_DATA_DIR/' /opt/paperless/paperless.conf
 sed -i "" -e  "/PAPERLESS_DATA_DIR/ a\\


### PR DESCRIPTION
Fixes https://github.com/ix-plugin-hub/iocage-plugin-index/issues/392.